### PR TITLE
Update baseline to 0.1.0-preview.1.0.0

### DIFF
--- a/src/Pure.RelationalSchema.Storage.Abstractions.Serialization.System/Pure.RelationalSchema.Storage.Abstractions.Serialization.System.csproj
+++ b/src/Pure.RelationalSchema.Storage.Abstractions.Serialization.System/Pure.RelationalSchema.Storage.Abstractions.Serialization.System.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <IsAotCompatible>false</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.0.2.1</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.1.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.RelationalSchema.Storage.Abstractions.Serialization.System</PackageId>


### PR DESCRIPTION
## Summary
- Updates `PackageValidationBaselineVersion` to `0.1.0-preview.1.0.0` following the release of that version

## Test plan
- [ ] CI build passes (package validation validates against the new baseline)